### PR TITLE
Fix yjs version string

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "rollup-plugin-typescript2": "^0.29.0",
     "typescript": "^4.1.3",
     "y-protocols": ">=1.0.4",
-    "yjs": "'13.5.2",
+    "yjs": "^13.5.2",
     "zustand": "^3.3.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Commit 3bbcf15 seems to have messed up the yjs version string in package.json; this fixes it.